### PR TITLE
Move calls to `theme_form_element_label()` outside the `switch` in `theme_form_element()` + fall back to `$element['#parents'][0]` for the title

### DIFF
--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -5039,7 +5039,7 @@ function theme_form_element_label($variables) {
   // If the element is required, a required marker is appended to the label.
   $required = !empty($element['#required']) ? theme('form_required_marker', array('element' => $element)) : '';
 
-  $title = filter_xss_admin($element['#title']);
+  $title = empty($element['#title']) ? $element['#parents'][0] : filter_xss_admin($element['#title']);
 
   $attributes = array();
   // Style the label as class option to display inline with the element.

--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -4955,6 +4955,8 @@ function theme_form_element($variables) {
     }
   }
 
+  $label = theme('form_element_label', $variables);
+
   $prefix = isset($element['#field_prefix']) ? '<span class="field-prefix">' . $element['#field_prefix'] . '</span> ' : '';
   $suffix = isset($element['#field_suffix']) ? ' <span class="field-suffix">' . $element['#field_suffix'] . '</span>' : '';
   $main_element = $description_before . $prefix . $element['#children'] . $suffix;
@@ -4962,11 +4964,11 @@ function theme_form_element($variables) {
   switch ($element['#title_display']) {
     case 'before':
     case 'invisible':
-      $output .= ' ' . theme('form_element_label', $variables) . ' ' . $main_element . "\n";
+      $output .= ' ' . $label . ' ' . $main_element . "\n";
       break;
 
     case 'after':
-      $output .= ' ' . $main_element . ' ' . theme('form_element_label', $variables) . "\n";
+      $output .= ' ' . $main_element . ' ' . $label . "\n";
       break;
 
     case 'none':

--- a/core/themes/bartik/css/colors.css
+++ b/core/themes/bartik/css/colors.css
@@ -11,7 +11,7 @@ body {
 .l-header {
   color: #fffeff;
   background-color: #000000;
-  background-image: linear-gradient(top, #000000 0%, #000001 100%);
+  background: linear-gradient(to bottom, #000000 0%, #000001 100%);
 }
 .l-header ul.menu > li > a {
   color: #e3e3e3;


### PR DESCRIPTION
Hey @herbdool, can you please consider merging this into your PR branch for https://github.com/backdrop/backdrop-issues/issues/1403?

I tested my theory, and if you check the last 2 commits here, you'll see that falling back to `$element['#parents'][0]` for the title fixes the failing tests that you were getting when moving the calls to `theme_form_element_label()` outside the `switch`: https://github.com/backdrop/backdrop/pull/4803

PS: the change in color.css is from https://github.com/backdrop/backdrop-issues/issues/6606 which was recently merged. You won't see that if you rebase your PR branch I expect.